### PR TITLE
[WIP] add option to report crashes on server side

### DIFF
--- a/lib/grpc/server/adapters/cowboy.ex
+++ b/lib/grpc/server/adapters/cowboy.ex
@@ -226,6 +226,9 @@ defmodule GRPC.Server.Adapters.Cowboy do
     dispatch_key = Module.concat(endpoint, Dispatch)
     :persistent_term.put(dispatch_key, dispatch)
 
+    crash_report_func = Keyword.get(opts, :crash_report, fn _exception -> :ok end)
+    :persistent_term.put(crash_report_key(endpoint), crash_report_func)
+
     idle_timeout = Keyword.get(opts, :idle_timeout) || :infinity
     num_acceptors = Keyword.get(opts, :num_acceptors) || @default_num_acceptors
     max_connections = Keyword.get(opts, :max_connections) || @default_max_connections
@@ -306,5 +309,14 @@ defmodule GRPC.Server.Adapters.Cowboy do
 
   defp servers_name(endpoint, _) do
     inspect(endpoint)
+  end
+
+  defp crash_report_key(endpoint) do
+    Module.concat(endpoint, CrashReport)
+  end
+
+  @spec crash_report(module) :: (exception :: Exception.t() -> :ok)
+  def crash_report(endpoint) do
+    :persistent_term.get(crash_report_key(endpoint), fn _exception -> :ok end)
   end
 end

--- a/lib/grpc/server/adapters/cowboy/handler_exception.ex
+++ b/lib/grpc/server/adapters/cowboy/handler_exception.ex
@@ -1,0 +1,12 @@
+defmodule GRPC.Server.Adapters.Cowboy.HandlerException do
+  defexception [:req, :kind, :reason, :stack]
+
+  def new(req, %{__exception__: _} = exception, stack \\ []) do
+    exception(req: req, kind: :error, reason: exception, stack: stack)
+  end
+
+  def message(%{req: req, kind: kind, reason: reason, stack: stack}) do
+    path = :cowboy_req.path(req)
+    "Exception raised while handling #{path}:\n" <> Exception.format_banner(kind, reason, stack)
+  end
+end

--- a/lib/grpc/server/supervisor.ex
+++ b/lib/grpc/server/supervisor.ex
@@ -40,7 +40,8 @@ defmodule GRPC.Server.Supervisor do
 
     * `:endpoint` - defines the endpoint module that will be started.
     * `:port` - the HTTP port for the endpoint.
-    * `:servers` - the list of servers that will be be started.
+    * `:servers` - the list of servers that will be started.
+    * `:crash_report` (optional) - A function that accepts an exception as single argument to be called for report crashes. Each adapter report crashes based on implementation details.
 
   Either `:endpoint` or `:servers` must be present, but not both.
   """

--- a/test/grpc/server/supervisor_test.exs
+++ b/test/grpc/server/supervisor_test.exs
@@ -7,10 +7,17 @@ defmodule GRPC.Server.SupervisorTest do
     def __meta__(_), do: [FeatureServer]
   end
 
+  require Logger
+
   describe "init/1" do
     test "does not start children if opts sets false" do
       assert {:ok, {%{strategy: :one_for_one}, []}} =
-               Supervisor.init(endpoint: MockEndpoint, port: 1234, start_server: false)
+               Supervisor.init(
+                 endpoint: MockEndpoint,
+                 port: 1234,
+                 start_server: false,
+                 crash_report: fn exception -> Logger.error(exception) end
+               )
     end
 
     test "fails if a tuple is passed" do


### PR DESCRIPTION
Improve crash report using a server side option to report crashes using a reporter of user's preference. E.g: Bugsnag

Example
```
Supervisor.init(endpoint: MockEndpoint, port: 1234, start_server: true, crash_report: &Bugsnag.report/1)
Supervisor.init(endpoint: MockEndpoint, port: 1234, start_server: true, crash_report: &Sentry.capture_exception/1)
Supervisor.init(endpoint: MockEndpoint, port: 1234, start_server: true, crash_report: &MyOwnExceptionSanitizer.capture/1)
```